### PR TITLE
Adds support for data-html="true"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can pass options in `data:`
 	      :'sweet-alert-type' => 'info',
 	      text: 'This is a subtitle',
 	      :'image-url' => '/pic.png'
-
+        html: false
         } 
 ```
 

--- a/lib/assets/javascripts/sweet-alert-confirm.js
+++ b/lib/assets/javascripts/sweet-alert-confirm.js
@@ -6,8 +6,8 @@
       type: 'warning',
       showCancelButton: true,
       confirmButtonColor: "#DD6B55",
-      confirmButtonText: "Ok"
-
+      confirmButtonText: "Ok",
+      html: false
     }
 
     //this.click(function(event) {
@@ -23,6 +23,7 @@
                           'confirmButtonText',
                           'cancelButtonText',
                           'closeOnConfirm',
+                          'html',
                           'imageUrl',
                           'allowOutsideClick',
                           'remote',


### PR DESCRIPTION
Thanks, this gem is super handy. I occasionally need the odd <br /> in the data-text field. This adds the option to pass data-html to swal().

Let me know if there's anything you want me to clean up this PR.