### PR TITLE
Initialize confirm dialogs on `page:update` Turbolinks 5 event

### DIFF
--- a/lib/assets/javascripts/sweet-alert-confirm.js
+++ b/lib/assets/javascripts/sweet-alert-confirm.js
@@ -102,7 +102,7 @@ var sweetAlertConfirmConfig = sweetAlertConfirmConfig || {}; // Add default conf
 
       return false;
   }
-  $(document).on('ready page:load ajaxComplete', function() {
+  $(document).on('ready page:update ajaxComplete', function() {
     $('[data-sweet-alert-confirm]').on('click', sweetAlertConfirm)
   });
 


### PR DESCRIPTION
Initialize confirm dialogs on page:update Turbolinks event

It fixes sweet alert confirm dialogs when the button or link was added to the DOM using partial replacements (Turbolinks 5).

Please note this event is fired when the page is loaded and also when the a partial replacement is made. Therefore, using this event instead of `page:load` covers more cases.

Users using Turbolinks 2.x should not be affected by the change, since the `page:update` event is also triggered just before `page:load` in this version.


PS Maybe this change fixes https://github.com/mois3x/sweet-alert-rails-confirm/issues/11?