### PR TITLE
Make sure the correct event happens after confirm

### DIFF
--- a/lib/assets/javascripts/sweet-alert-confirm.js
+++ b/lib/assets/javascripts/sweet-alert-confirm.js
@@ -16,7 +16,7 @@ var sweetAlertConfirmConfig = sweetAlertConfirmConfig || {}; // Add default conf
       swalDefaultOptions.confirmButtonColor = sweetAlertConfirmConfig.confirmButtonColor
     }
 
-      $linkToVerify = $(this)
+      $linkToVerify = $(this);
       var swalOptions = swalDefaultOptions;
       var optionKeys = [
                           'confirm',
@@ -36,7 +36,12 @@ var sweetAlertConfirmConfig = sweetAlertConfirmConfig || {}; // Add default conf
                           'method',
                           'function'
                         ];
-      
+
+      if ($linkToVerify.data('swal-confirmed')) {
+        $linkToVerify.data('swal-confirmed', false);
+        return true;
+      }
+
       function afterAlertCallback(r){
         if (nameFunction) {
           window[nameFunction]();
@@ -66,7 +71,7 @@ var sweetAlertConfirmConfig = sweetAlertConfirmConfig || {}; // Add default conf
               $linkToVerify.closest('form').submit();
             }
             else {
-              window.location.href = $linkToVerify.attr('href');
+              $linkToVerify.data('swal-confirmed', true).click();
             }
       
           }


### PR DESCRIPTION
It's important to trigger the click instead of updating the window.location because not all links are meant to change the location. Triggering the click again makes sure that the expected event will occur.

I encountered this problem when trying to use sweet alert confirm together with `link_to_remove_association` from [nathanvda/cocoon](https://github.com/nathanvda/cocoon)