### PR TITLE
Consider new Turbolinks 5 event names

### DIFF
--- a/lib/assets/javascripts/sweet-alert-confirm.js
+++ b/lib/assets/javascripts/sweet-alert-confirm.js
@@ -103,11 +103,11 @@ var sweetAlertConfirmConfig = sweetAlertConfirmConfig || {}; // Add default conf
 
       return false;
   }
-  $(document).on('ready page:update ajaxComplete', function() {
+  $(document).on('ready turbolinks:load page:update ajaxComplete', function() {
     $('[data-sweet-alert-confirm]').on('click', sweetAlertConfirm)
   });
 
-  $(document).on('ready page:load', function() {
+  $(document).on('ready turbolinks:load page:load', function() {
     //To avoid "Uncaught TypeError: Cannot read property 'querySelector' of null" on turbolinks
     if (typeof window.sweetAlertInitialize === 'function') {
       window.sweetAlertInitialize();


### PR DESCRIPTION
Turbolinks 5 has renamed their events, so we should rely on the `turbolinks:load` to make sweet alerts work.

I'm adding this event but not removing `page:load` and `page:update` in order to support the [classic version of Turbolinks](https://github.com/turbolinks/turbolinks-classic)

In this way, rails apps using either version of TL are covered.