### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ gem 'sweet-alert-confirm'
 Add the following to application.js:
 
 ```javascript
-//= require sweetalert
+//= require sweet-alert
 //= require sweet-alert-confirm
 ```
 Add the following to application.css:
 
 ```css
 /*
- *= require sweetalert
+ *= require sweet-alert
  */
 ```
 


### PR DESCRIPTION
Updated README to include hyphen in sweet-alert js/css require statements. Rails was angry unless I used the hyphen like it's specified in the gem. Still getting errors on the data: confirm but this got me past the first set of errors.