### PR TITLE
Account for new turbo events

### DIFF
--- a/lib/assets/javascripts/sweet-alert-confirm.js
+++ b/lib/assets/javascripts/sweet-alert-confirm.js
@@ -103,11 +103,11 @@ var sweetAlertConfirmConfig = sweetAlertConfirmConfig || {}; // Add default conf
 
       return false;
   }
-  $(document).on('ready turbolinks:load page:update ajaxComplete', function() {
+  $(document).on('ready turbolinks:load turbo:load page:update ajaxComplete', function() {
     $('[data-sweet-alert-confirm]').on('click', sweetAlertConfirm)
   });
 
-  $(document).on('ready turbolinks:load page:load', function() {
+  $(document).on('ready turbolinks:load turbo:load page:load', function() {
     //To avoid "Uncaught TypeError: Cannot read property 'querySelector' of null" on turbolinks
     if (typeof window.sweetAlertInitialize === 'function') {
       window.sweetAlertInitialize();


### PR DESCRIPTION
With Hotwire Turbo, Turbo has new event names, so we should rely on the `turbo:load` to make sweet alerts work. While adding this event we are also keeping turbolinks and page events for compatibility reasons.
